### PR TITLE
Options for vieSemanticAloha

### DIFF
--- a/vie-aloha.js
+++ b/vie-aloha.js
@@ -1,5 +1,13 @@
 (function($){
-    $.fn.vieSemanticAloha = function() {
+    $.fn.vieSemanticAloha = function(options) {
+        
+        // Default settings
+        var opt = { 
+                beforeEditing: null
+        };
+        $.extend(opt, options);
+
+
         this.each(function() {
             var containerInstance = VIE.ContainerManager.getInstanceForContainer(jQuery(this));
             if (typeof containerInstance.editables === 'undefined') {
@@ -7,6 +15,14 @@
             }
             VIE.ContainerManager.findContainerProperties(this, false).each(function() {
                 var containerProperty = jQuery(this);
+
+                // Call the configured beforeEditing function that may modify 
+                // the content of the editable before editing is possible
+                if(opt.beforeEditing != null) {
+                    opt.beforeEditing(containerProperty);
+                }
+
+
                 var propertyName = containerProperty.attr('property');
 
                 if (containerInstance.get(propertyName) instanceof Array) {


### PR DESCRIPTION
Hello,

When using wordpress i need to replace the deliviered content since some wordpress plugins may alter the content though a chain of filters. Therefore i added the beforeEditing option to allow replacement of the content.

Perhaps you know a better way to deal with this requirement using the backbone functionality?

Greetings

Jotschi
