### PR TITLE
without "!== undefined" it writes the value not to the content attr. -- o

### DIFF
--- a/vie.js
+++ b/vie.js
@@ -1119,7 +1119,7 @@
             // values for elements where the HTML presentation differs from the
             // actual value.
             var content = element.attr('content');
-            if (content) {
+            if (content !== undefined) {
                 element.attr('content', value);
                 return;
             }


### PR DESCRIPTION
without "!== undefined" it writes the value not to the content attr. -- only as html content (happend after backbone update; after reload of the page the value was fine (discovered in palsu after adding a task))
