### PR TITLE
removed supefluos and troublesome comma

### DIFF
--- a/src/Util.js
+++ b/src/Util.js
@@ -705,7 +705,7 @@ VIE.Util = {
                           ];
                       };
                   }(service.vie.namespaces)
-              },
+              }
         ];
         return res;
     },


### PR DESCRIPTION
Internet Explorer has a non-standard intepretation of trailing commas. Arrays will have the wrong length and objects will not parse at all. (according to webminifier-maven-plugin)
