### PR TITLE
URIs don't begin with < or end with >

### DIFF
--- a/src/Collection.js
+++ b/src/Collection.js
@@ -20,7 +20,7 @@ VIE.prototype.Collection = Backbone.Collection.extend({
                 id = id.replace("_:bnode", 'c');
                 return this._byCid[id];
             } else {
-                return this._byId["<" + id + ">"];
+                return this._byId[id];
             }
         } else {
             id = this.toReference(id);
@@ -104,7 +104,7 @@ VIE.prototype.Collection = Backbone.Collection.extend({
     },
 
     isReference: function(uri){
-        var matcher = new RegExp("^\\<([^\\>]*)\\>$");
+        var matcher = new RegExp("^([^\\>]*)$");
         if (matcher.exec(uri)) {
             return true;
         }
@@ -115,7 +115,7 @@ VIE.prototype.Collection = Backbone.Collection.extend({
         if (this.isReference(uri)) {
             return uri;
         }
-        return '<' + uri + '>';
+        return uri;
     },
         
     fromReference: function(uri){

--- a/src/Entity.js
+++ b/src/Entity.js
@@ -233,7 +233,7 @@ VIE.prototype.Entity = function(attrs, opts) {
         },
 
         isReference: function(uri){
-            var matcher = new RegExp("^\\<([^\\>]*)\\>$");
+            var matcher = new RegExp("^([^\\>]*)$");
             if (matcher.exec(uri)) {
                 return true;
             }
@@ -254,12 +254,12 @@ VIE.prototype.Entity = function(attrs, opts) {
             }
             else if (ns.isCurie(uri)) {
                 ret = ns.uri(uri);
-                if (ret === "<" + ns.base() + uri + ">") {
+                if (ret === ns.base() + uri) {
                     /* no base namespace extension with IDs */
-                    ret = '<' + uri + '>';
+                    ret = uri;
                 }
             } else if (!ns.isUri(uri)) {
-                ret = '<' + uri + '>';
+                ret = uri;
             }
             return ret;
         },

--- a/src/Util.js
+++ b/src/Util.js
@@ -50,7 +50,8 @@ VIE.Util = {
                         ((safe)? "]" : "");
             }
         }
-        throw new Error("No prefix found for URI '" + uri + "'!");
+	    return uri;
+//        throw new Error("No prefix found for URI '" + uri + "'!");
     },
 
 // ### VIE.Util.isCurie(curie, namespaces)
@@ -78,15 +79,15 @@ VIE.Util = {
 //     VIE.Util.isCurie(scurie, ns); // --> true
 //     VIE.Util.isCurie(text, ns);   // --> false
     isCurie : function (curie, namespaces) {
+        try {
+            VIE.Util.toUri(curie, namespaces);
+            return true;
+        } catch (e) {
+            return false;
+        }
         if (VIE.Util.isUri(curie)) {
             return false;
         } else {
-            try {
-                VIE.Util.toUri(curie, namespaces);
-                return true;
-            } catch (e) {
-                return false;
-            }
         }
     },
 
@@ -117,12 +118,12 @@ VIE.Util = {
         for (var prefix in namespaces.toObj()) {
             if (prefix !== "" && (curie.indexOf(prefix + ":") === 0 || curie.indexOf("[" + prefix + ":") === 0)) {
                 var pattern = new RegExp("^" + "\\[{0,1}" + prefix + delim);
-                return "<" + curie.replace(pattern, namespaces.get(prefix)).replace(/\]{0,1}$/, '') + ">";
+                return curie.replace(pattern, namespaces.get(prefix)).replace(/\]{0,1}$/, '');
             }
         }
         /* check for the default namespace */
         if (curie.indexOf(delim) === -1) {
-            return "<" + namespaces.base() + curie + ">";
+            return namespaces.base() + curie;
         }
         throw new Error("No prefix found for CURIE '" + curie + "'!");
     },
@@ -142,7 +143,7 @@ VIE.Util = {
 //     VIE.Util.isUri(uri);   // --> true
 //     VIE.Util.isUri(curie); // --> false
     isUri : function (something) {
-        return (typeof something === "string" && something.search(/^<.+>$/) === 0);
+        return (typeof something === "string" && something.search(/^.+$/) === 0);
     },
 
 // ### VIE.Util.mapAttributeNS(attr, ns)
@@ -167,9 +168,9 @@ VIE.Util = {
             a = ns.uri(attr);
         } else if (!ns.isUri(attr)) {
             if (attr.indexOf(":") === -1) {
-                a = '<' + ns.base() + attr + '>';
+                a =  ns.base() + attr;
             } else {
-                a = '<' + attr + '>';
+                a =  attr ;
             }
         }
         return a;
@@ -388,12 +389,12 @@ VIE.Util = {
         var jsonLD = [];
         _.forEach(results, function(value, key) {
             var entity = {};
-            entity['@subject'] = '<' + key + '>';
+            entity['@subject'] =  key ;
             _.forEach(value, function(triples, predicate) {
-                predicate = '<' + predicate + '>';
+                //predicate = '<' + predicate;
                 _.forEach(triples, function(triple) {
                     if (triple.type === 'uri') {
-                        triple.value = '<' + triple.value + '>';
+                        triple.value = triple.value;
                     }
 
                     if (entity[predicate] && !_.isArray(entity[predicate])) {
@@ -431,7 +432,7 @@ VIE.Util = {
         if (!SchemaOrg) {
             throw new Error("Please load the schema.json file.");
         }
-        vie.types.remove("<http://schema.org/Thing>");
+        vie.types.remove("http://schema.org/Thing");
         
         var baseNSBefore = (baseNS)? baseNS : vie.namespaces.base();
         vie.namespaces.base(baseNS);
@@ -613,11 +614,11 @@ VIE.Util = {
                          return [
                              jQuery.rdf.triple(this.subject.toString(),
                                  'a',
-                                 '<' + ns.base() + 'Person>', {
+                                  ns.base() + 'Person', {
                                      namespaces: ns.toObj()
                                  }),
                              jQuery.rdf.triple(this.subject.toString(),
-                                 '<' + ns.base() + 'name>',
+                                 ns.base() + 'name',
                                  this.label, {
                                      namespaces: ns.toObj()
                                  })
@@ -636,11 +637,11 @@ VIE.Util = {
                           return [
                               jQuery.rdf.triple(this.subject.toString(),
                                   'a',
-                                  '<' + ns.base() + 'Person>', {
+                                   ns.base() + 'Person', {
                                       namespaces: ns.toObj()
                                   }),
                               jQuery.rdf.triple(this.subject.toString(),
-                                  '<' + ns.base() + 'name>',
+                                  ns.base() + 'name',
                                   this.label, {
                                       namespaces: ns.toObj()
                                   })
@@ -659,11 +660,11 @@ VIE.Util = {
                           return [
                           jQuery.rdf.triple(this.subject.toString(),
                               'a',
-                              '<' + ns.base() + 'Place>', {
+                              ns.base() + 'Place', {
                                   namespaces: ns.toObj()
                               }),
                           jQuery.rdf.triple(this.subject.toString(),
-                                  '<' + ns.base() + 'name>',
+                                  ns.base() + 'name',
                               this.label.toString(), {
                                   namespaces: ns.toObj()
                               })
@@ -684,21 +685,21 @@ VIE.Util = {
                           return [
                           jQuery.rdf.triple(this.subject.toString(),
                               'a',
-                              '<' + ns.base() + 'City>', {
+                              ns.base() + 'City', {
                                   namespaces: ns.toObj()
                               }),
                           jQuery.rdf.triple(this.subject.toString(),
-                                  '<' + ns.base() + 'name>',
+                                   ns.base() + 'name',
                               this.label.toString(), {
                                   namespaces: ns.toObj()
                               }),
                           jQuery.rdf.triple(this.subject.toString(),
-                                  '<' + ns.base() + 'description>',
+                                  ns.base() + 'description',
                               this.abs.toString(), {
                                   namespaces: ns.toObj()
                               }),
                           jQuery.rdf.triple(this.subject.toString(),
-                                  '<' + ns.base() + 'containedIn>',
+                                  ns.base() + 'containedIn',
                               this.country.toString(), {
                                   namespaces: ns.toObj()
                               })
@@ -746,9 +747,9 @@ VIE.Util = {
 				'left' : [ '?subject a dbpedia:' + key, '?subject rdfs:label ?label' ],
 				'right' : function(ns) {
 					return function() {
-						return [ jQuery.rdf.triple(this.subject.toString(), 'a', '<' + ns.base() + mapping[key] + '>', {
+						return [ jQuery.rdf.triple(this.subject.toString(), 'a', ns.base() + mapping[key], {
 							namespaces : ns.toObj()
-						}), jQuery.rdf.triple(this.subject.toString(), '<' + ns.base() + 'name>', this.label.toString(), {
+						}), jQuery.rdf.triple(this.subject.toString(), ns.base() + 'name', this.label.toString(), {
 							namespaces : ns.toObj()
 						}) ];
 					};

--- a/src/service/RdfaService.js
+++ b/src/service/RdfaService.js
@@ -252,7 +252,7 @@ VIE.prototype.RdfaService.prototype = {
         if (jQuery(element).attr('typeof') !== this.options.attributeExistenceComparator) {
             type = jQuery(element).attr('typeof');
             if (type.indexOf("://") !== -1) {
-                return "<" + type + ">";
+                return type;
             } else {
                 return type;
             }
@@ -308,7 +308,7 @@ VIE.prototype.RdfaService.prototype = {
         if (subject.indexOf('<') === 0) {
             return subject;
         }
-        return "<" + subject + ">";
+        return subject;
     },
     
     setElementSubject : function(subject, element) {
@@ -416,13 +416,13 @@ VIE.prototype.RdfaService.prototype = {
         // RDF resource.
         var resource = element.attr('resource');
         if (resource) {
-            return ["<" + resource + ">"];
+            return [resource];
         }
                 
         // `href` attribute also links to another RDF resource.
         var href = element.attr('href');
         if (href && element.attr('rel') === predicate) {
-            return ["<" + href + ">"];
+            return [href];
         }
     
         // If the predicate is a relation, we look for identified child objects


### PR DESCRIPTION
Especially ones embedded in RDFa. You're probably thinking of N3-based representations, but the <>s aren't actually part of the URI. I may have missed some edge cases where you were relying on the <>s for something, but at least now your URIs aren't broken, and you can accept real ones.
