### PR TITLE
[BUGFIX] make type loading order independent

### DIFF
--- a/src/Util.js
+++ b/src/Util.js
@@ -509,7 +509,7 @@ VIE.Util = {
 
             for (var i = 0; i < ancestors.length; i++) {
                 var supertype = (vie.types.get(ancestors[i]))? vie.types.get(ancestors[i]) :
-                    typeHelper.call(vie, SchemaOrg.types[ancestors[i]].supertypes, ancestors[i], typeProps.call(vie, ancestors[i]));
+                    typeHelper.call(vie, SchemaOrg.types[ancestors[i]].supertypes, ancestors[i], typeProps.call(vie, ancestors[i]), metadataHelper(SchemaOrg.types[ancestors[i]]));
                 type.inherit(supertype);
             }
             if (id === "Thing" && !type.isof("owl:Thing")) {

--- a/test/core/schema.js
+++ b/test/core/schema.js
@@ -69,5 +69,46 @@ test("Initialization", function() {
             start();
         }
     });
-    
+
+});
+
+test("Hierarchy Metadata", function() {
+    var z = new VIE();
+    z.namespaces.addOrReplace('typo3', 'http://typo3.org/ns');
+
+    ok(z.loadSchema);
+    equal(typeof z.loadSchema, "function");
+
+    VIE.Util.loadSchemaOrg(z, {
+        properties: {},
+        types: {
+            'typo3:Foo.Bar': {
+                id: 'typo3:Foo.Bar',
+                metadata: {
+                    group: 'Test',
+                    other: 'Foo'
+                },
+                supertypes: ['typo3:Other'],
+                subtypes: [],
+                specific_properties: [],
+                properties: []
+            },
+            'typo3:Other': {
+                id: 'typo3:Other',
+                metadata: {
+                    some: 'thing',
+                    prop2: 'val2'
+                },
+                subtypes: ['typo3:Foo.Bar'],
+                supertypes: [],
+                specific_properties: [],
+                properties: []
+            }
+        }
+    }, null);
+
+    equal(z.types.get('typo3:Foo.Bar').metadata.group, 'Test');
+    equal(z.types.get('typo3:Foo.Bar').metadata.other, 'Foo');
+    equal(z.types.get('typo3:Other').metadata.some, 'thing');
+    equal(z.types.get('typo3:Other').metadata.prop2, 'val2');
 });


### PR DESCRIPTION
For sub- and supertypes to properly work and contain all metadata,
the supertypes had to be loaded _before_ the subtypes.

This change fixes this; making the supertype loading order agnostic,
also retaining the metadata of the super type.

This is needed for TYPO3 Neos to work properly, as we make escessive use of supertypes and metadata.
