### PR TITLE
Corrected issue where the score was assigned to NaN.

### DIFF
--- a/src/Util.js
+++ b/src/Util.js
@@ -287,7 +287,7 @@ VIE.Util = {
     a score. It returns the value with the best score.
     */
     getPreferredLangForPreferredProperty: function(entity, preferredFields, preferredLanguages) {
-      var l, labelArr, lang, p, property, resArr, valueArr, _len, _len2,
+      var labelArr, lang, property, resArr, valueArr, _len, _len2,
         _this = this;
       resArr = [];
       /* Try to find a label in the preferred language
@@ -305,8 +305,8 @@ VIE.Util = {
               best candidate with the first preferred language
               and first preferred property
               */
-              var labelLang, score, value;
-              score = p;
+              var labelLang, value;
+              var score = p = l = 0;
               labelLang = label["@language"];
               /*
                                       legacy code for compatibility with uotdated stanbol,


### PR DESCRIPTION
Corrected issue where the score (of the type Number) was assigned to NaN values when trying to get preferred languages of an entity.

This should replace the previous pull #153
