### PR TITLE
Wrap VIE in the current scope (window by default)

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -13,7 +13,7 @@ See http://viejs.org for more information
       options:
         stripBanners: true
         banner: "#{banner}(function () {"
-        footer: "})();"
+        footer: "})(this);"
       full:
         src: [
           'src/VIE.js'


### PR DESCRIPTION
Hi Henri, we need this in Neos atm to wrap VIE in our own custom requirejs managed scope. Afaik tests run and this should not cause any error at first sight.
